### PR TITLE
Give import_knowns a default value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ meta.json
 *.ankiaddon
 .sourcery.yaml
 venv/*
+.venv/*
+.vscode/
 .DS_Store

--- a/LingqAnkiSync/LingqApi.py
+++ b/LingqAnkiSync/LingqApi.py
@@ -4,7 +4,7 @@ from typing import List
 from Models.Lingq import Lingq
 
 class LingqApi:
-    def __init__(self, apiKey: str, languageCode: str, import_knowns: bool):
+    def __init__(self, apiKey: str, languageCode: str, import_knowns: bool = True):
         self.apiKey = apiKey
         self.languageCode = languageCode
         self.import_knowns = import_knowns

--- a/Tests/test_LingqApi.py
+++ b/Tests/test_LingqApi.py
@@ -5,26 +5,16 @@ sys.path.append(
     os.path.realpath(f"{os.path.dirname(__file__)}/../LingqAnkiSync")
 )
 from LingqApi import LingqApi
-import pytest
 
 class TestLingqApi:
     def test_should_set_import_knowns_to_true_by_default(self):
-        # Arrange & Act
         api = LingqApi("test_key", "test_lang")
-
-        # Assert
         assert api.import_knowns == True
 
     def test_should_set_import_knowns_to_false_when_specified(self):
-        # Arrange & Act
         api = LingqApi("test_key", "test_lang", import_knowns=False)
-
-        # Assert
         assert api.import_knowns == False
 
     def test_should_set_import_knowns_to_true_when_specified(self):
-        # Arrange & Act
         api = LingqApi("test_key", "test_lang", import_knowns=True)
-
-        # Assert
         assert api.import_knowns == True

--- a/Tests/test_LingqApi.py
+++ b/Tests/test_LingqApi.py
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+import sys, os
+sys.path.append(
+    os.path.realpath(f"{os.path.dirname(__file__)}/../LingqAnkiSync")
+)
+from LingqApi import LingqApi
+import pytest
+
+class TestLingqApi:
+    def test_should_set_import_knowns_to_true_by_default(self):
+        # Arrange & Act
+        api = LingqApi("test_key", "test_lang")
+
+        # Assert
+        assert api.import_knowns == True
+
+    def test_should_set_import_knowns_to_false_when_specified(self):
+        # Arrange & Act
+        api = LingqApi("test_key", "test_lang", import_knowns=False)
+
+        # Assert
+        assert api.import_knowns == False
+
+    def test_should_set_import_knowns_to_true_when_specified(self):
+        # Arrange & Act
+        api = LingqApi("test_key", "test_lang", import_knowns=True)
+
+        # Assert
+        assert api.import_knowns == True


### PR DESCRIPTION
The `import_knowns` feature implemented in https://github.com/thags/lingqAnkiSync/pull/41 broke the `SyncLingqStatusToLingq` method because of the missing import_known argument for the `LingqApi` constructor. This PR fixes that by giving the `import_knowns` argument a default value.